### PR TITLE
fix: workspace definitions in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "workspaces": [
-        "packages\\core",
-        "packages\\web",
-        "packages\\cli"
+        "packages/core",
+        "packages/web",
+        "packages/cli"
       ],
       "devDependencies": {
         "typescript": "^4.7.4"

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "author": "Dávid Szabó",
   "license": "ISC",
   "workspaces": [
-    "packages\\core",
-    "packages\\web",
-    "packages\\cli"
+    "packages/core",
+    "packages/web",
+    "packages/cli"
   ],
   "devDependencies": {
     "typescript": "^4.7.4"


### PR DESCRIPTION
The `package.json` "workspaces" array included double-back-slashes when specifying the workspace directories.  I suspect this was simply caused when copy-and-pasting content from another source.  It meant that following the basic steps in the `README.md` would fail.

The related blog post is really well structured -- thanks for writing that up!